### PR TITLE
Adjust optimization API fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,12 +90,14 @@ def deepseek_optimize_diagnosis_codes(dataset_path, available_codes):
 
     RESPOND IN VALID JSON FORMAT ONLY:
     {{
-        "pattern_analysis": "Detailed analysis of high-value patterns found in dataset",
         "pdx": "selected_primary_diagnosis_code",
         "sdx": ["sdx1_code", "sdx2_code", "sdx3_code", "sdx4_code", "sdx5_code", "sdx6_code", "sdx7_code", "sdx8_code", "sdx9_code", "sdx10_code", "sdx11_code", "sdx12_code"],
-        "reasoning": "Detailed explanation of why this combination should maximize adj RW",
         "estimated_adj_rw": 0.0,
-        "confidence_level": "1-100 percentage scale"
+        "confidence_level": "1-100 percentage scale",
+        "primary_weight": 0.0,
+        "secondary_weight": 0.0,
+        "complexity_factor": 0.0,
+        "recommendations": ["Rec 1", "Rec 2", "Rec 3"]
     }}
     """
     
@@ -260,13 +262,17 @@ if __name__ == "__main__":
         print("\n" + "="*60)
         print("🎯 DEEPSEEK OPTIMIZATION RESULT")
         print("="*60)
-        print(f"📊 Pattern Analysis:\n{result['pattern_analysis']}\n")
         print(f"🏥 Primary Diagnosis (pdx): {result['pdx']}")
         print("\n📋 Secondary Diagnoses:")
         for i, code in enumerate(result['sdx'], 1):
             print(f"   sdx{i:2d}: {code}")
         print(f"\n💰 Estimated adj RW: {result['estimated_adj_rw']:.2f}")
         print(f"🎯 Confidence Level: {result['confidence_level']}/10")
-        print(f"\n💡 Reasoning:\n{result['reasoning']}")
+        print(f"\n📈 Primary Weight: {result['primary_weight']}")
+        print(f"📉 Secondary Weight: {result['secondary_weight']}")
+        print(f"⚙️ Complexity Factor: {result['complexity_factor']}")
+        print("\n📝 Recommendations:")
+        for rec in result.get('recommendations', []):
+            print(f"  - {rec}")
     else:
         print("❌ Optimization failed. Please check your API key and data file.")

--- a/apps/api/src/schemas/index.ts
+++ b/apps/api/src/schemas/index.ts
@@ -15,12 +15,14 @@ export const optimizationRequestSchema = z.object({
 
 export const optimizationResponseSchema = z.object({
   success: z.boolean(),
-  patternAnalysis: z.string().optional(),
   pdx: z.string().optional(),
   sdx: z.array(z.string()).optional(),
-  reasoning: z.string().optional(),
   estimatedAdjRw: z.number().optional(),
   confidenceLevel: z.string().optional(),
+  primaryWeight: z.number().optional(),
+  secondaryWeight: z.number().optional(),
+  complexityFactor: z.number().optional(),
+  recommendations: z.array(z.string()).max(3).optional(),
   errorMessage: z.string().optional(),
 });
 

--- a/apps/api/src/services/optimization.service.ts
+++ b/apps/api/src/services/optimization.service.ts
@@ -61,12 +61,14 @@ export class OptimizationService {
 
       return {
         success: true,
-        patternAnalysis: result.patternAnalysis,
         pdx: result.pdx,
         sdx: result.sdx,
-        reasoning: result.reasoning,
         estimatedAdjRw: result.estimatedAdjRw,
         confidenceLevel: result.confidenceLevel,
+        primaryWeight: result.primaryWeight,
+        secondaryWeight: result.secondaryWeight,
+        complexityFactor: result.complexityFactor,
+        recommendations: result.recommendations,
       };
     } catch (error) {
       if (error instanceof ApiError) {
@@ -115,12 +117,14 @@ SELECTION CRITERIA:
 
 RESPOND IN VALID JSON FORMAT ONLY:
 {
-  "pattern_analysis": "Detailed analysis of high-value patterns found in dataset",
   "pdx": "selected_primary_diagnosis_code",
   "sdx": ["sdx1_code", "sdx2_code", "sdx3_code", "sdx4_code", "sdx5_code", "sdx6_code", "sdx7_code", "sdx8_code", "sdx9_code", "sdx10_code", "sdx11_code", "sdx12_code"],
-  "reasoning": "Detailed explanation of why this combination should maximize adj RW",
   "estimated_adj_rw": 0.0,
-  "confidence_level": "1-100"
+  "confidence_level": "1-100",
+  "primary_weight": 0.0,
+  "secondary_weight": 0.0,
+  "complexity_factor": 0.0,
+  "recommendations": ["Rec 1", "Rec 2", "Rec 3"]
 }`;
   }
 
@@ -189,23 +193,27 @@ RESPOND IN VALID JSON FORMAT ONLY:
     console.log(result);
 
     if (
-      typeof result.pattern_analysis !== 'string' ||
       typeof result.pdx !== 'string' ||
       !Array.isArray(result.sdx) ||
-      typeof result.reasoning !== 'string' ||
       typeof result.estimated_adj_rw !== 'number' ||
-      typeof result.confidence_level !== 'number'
+      typeof result.confidence_level !== 'number' ||
+      typeof result.primary_weight !== 'number' ||
+      typeof result.secondary_weight !== 'number' ||
+      typeof result.complexity_factor !== 'number' ||
+      !Array.isArray(result.recommendations)
     ) {
       throw new ApiError('Invalid optimization result format', 500);
     }
 
     return {
-      patternAnalysis: result.pattern_analysis,
       pdx: result.pdx,
       sdx: result.sdx.filter((code): code is string => typeof code === 'string'),
-      reasoning: result.reasoning,
       estimatedAdjRw: result.estimated_adj_rw,
       confidenceLevel: result.confidence_level.toString(),
+      primaryWeight: result.primary_weight,
+      secondaryWeight: result.secondary_weight,
+      complexityFactor: result.complexity_factor,
+      recommendations: result.recommendations.filter((item): item is string => typeof item === 'string').slice(0, 3),
     };
   }
 

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -20,18 +20,22 @@ export interface OptimizationRequest {
 export interface OptimizationResponse {
   /** Whether the optimization was successful */
   success: boolean;
-  /** Analysis of patterns found in the dataset */
-  patternAnalysis?: string;
   /** Selected primary diagnosis code */
   pdx?: string;
   /** Selected secondary diagnosis codes */
   sdx?: string[];
-  /** Reasoning behind the selection */
-  reasoning?: string;
   /** Estimated adjusted Relative Weight */
   estimatedAdjRw?: number;
   /** Confidence level of the optimization */
   confidenceLevel?: string;
+  /** Calculated weight of the primary diagnosis */
+  primaryWeight?: number;
+  /** Combined weight of the secondary diagnoses */
+  secondaryWeight?: number;
+  /** Overall complexity adjustment factor */
+  complexityFactor?: number;
+  /** List of additional recommendations */
+  recommendations?: string[];
   /** Error message if optimization failed */
   errorMessage?: string;
 }
@@ -69,12 +73,14 @@ export interface DeepSeekResponse {
  * DeepSeek optimization result
  */
 export interface DeepSeekOptimizationResult {
-  patternAnalysis: string;
   pdx: string;
   sdx: string[];
-  reasoning: string;
   estimatedAdjRw: number;
   confidenceLevel: string;
+  primaryWeight: number;
+  secondaryWeight: number;
+  complexityFactor: number;
+  recommendations: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- update optimization response types with new weights, complexity, and recommendations
- revise schema and service logic for new DeepSeek result format
- remove pattern analysis and reasoning output
- update Python helper script with new fields

## Testing
- `bun run src/index.ts` *(fails: Cannot find package 'hono')*

------
https://chatgpt.com/codex/tasks/task_e_6854e6e4f2e08326b619a4bdeaf27b2e