### PR TITLE
Integrate optimize API into web ranking

### DIFF
--- a/apps/web/app/libs/http.ts
+++ b/apps/web/app/libs/http.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios';
 
 function getBaseURL() {
-  const fallback = 'http://localhost:4000';
+  const fallback = 'http://localhost:8000';
   if (typeof window === 'undefined') {
     return process.env.API_ENDPOINT || fallback;
   }

--- a/apps/web/app/libs/optimizer.ts
+++ b/apps/web/app/libs/optimizer.ts
@@ -1,0 +1,25 @@
+import { apiPost } from './http'
+
+export interface OptimizationRequest {
+  availableCodes: string[]
+  maxSecondaryDiagnoses?: number
+}
+
+export interface OptimizationResponse {
+  success: boolean
+  pdx?: string
+  sdx?: string[]
+  estimatedAdjRw?: number
+  confidenceLevel?: string
+  primaryWeight?: number
+  secondaryWeight?: number
+  complexityFactor?: number
+  recommendations?: string[]
+  errorMessage?: string
+}
+
+export async function optimizeDiagnosis(
+  req: OptimizationRequest,
+): Promise<OptimizationResponse> {
+  return apiPost<OptimizationResponse>('/optimize', req)
+}


### PR DESCRIPTION
## Summary
- add optimizer API helper
- call `/optimize` endpoint from ranking interface
- use API result to populate ranking and AdjRw data
- set web API base URL to port 8000

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path' due to environment)*
- `npm run typecheck` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6854e921fa0c8326a72e6887cec0ecbb