### PR TITLE
Change pdx/sdx to return IcdCode objects

### DIFF
--- a/apps/api/src/schemas/index.ts
+++ b/apps/api/src/schemas/index.ts
@@ -13,10 +13,17 @@ export const optimizationRequestSchema = z.object({
   maxSecondaryDiagnoses: z.number().int().min(1).max(15).optional().default(12),
 });
 
+const icdCodeSchema = z.object({
+  code: z.string(),
+  description: z.string(),
+  confidence: z.number(),
+  category: z.string().optional(),
+})
+
 export const optimizationResponseSchema = z.object({
   success: z.boolean(),
-  pdx: z.string().optional(),
-  sdx: z.array(z.string()).optional(),
+  pdx: icdCodeSchema.optional(),
+  sdx: z.array(icdCodeSchema).optional(),
   estimatedAdjRw: z.number().optional(),
   confidenceLevel: z.string().optional(),
   primaryWeight: z.number().optional(),

--- a/apps/api/src/services/optimization.service.ts
+++ b/apps/api/src/services/optimization.service.ts
@@ -3,6 +3,7 @@ import type {
   DeepSeekOptimizationResult,
   OptimizationResponse,
   AdjRwResult,
+  IcdCode,
 } from '../types';
 import { DeepSeekService } from './deepseek.service';
 import { ApiError, prepareDatasetSummary, extractJsonFromResponse } from '../utils';
@@ -62,8 +63,8 @@ export class OptimizationService {
 
       return {
         success: true,
-        pdx: result.pdx,
-        sdx: result.sdx,
+        pdx: this.mapToIcdCode(result.pdx),
+        sdx: result.sdx.map((c) => this.mapToIcdCode(c)),
         estimatedAdjRw: result.estimatedAdjRw,
         confidenceLevel: result.confidenceLevel,
         primaryWeight: result.primaryWeight,
@@ -294,6 +295,14 @@ Respond ONLY with valid JSON in the format:
       complexityFactor: result.complexity_factor,
       recommendations: result.recommendations.filter((item): item is string => typeof item === 'string').slice(0, 3),
     };
+  }
+
+  private mapToIcdCode(code: string): IcdCode {
+    return {
+      code,
+      description: code,
+      confidence: 1,
+    }
   }
 
   /**

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -3,6 +3,16 @@
  */
 
 /**
+ * ICD-10 code structure returned by the API
+ */
+export interface IcdCode {
+  code: string
+  description: string
+  confidence: number
+  category?: string
+}
+
+/**
  * Optimization request payload
  */
 export interface OptimizationRequest {
@@ -46,9 +56,9 @@ export interface OptimizationResponse extends AdjRwResult {
   /** Whether the optimization was successful */
   success: boolean;
   /** Selected primary diagnosis code */
-  pdx?: string;
+  pdx?: IcdCode;
   /** Selected secondary diagnosis codes */
-  sdx?: string[];
+  sdx?: IcdCode[];
   /** Error message if optimization failed */
   errorMessage?: string;
 }

--- a/apps/web/app/components/ranking-interface.tsx
+++ b/apps/web/app/components/ranking-interface.tsx
@@ -14,6 +14,7 @@ import { SortableItem } from "~/components/sortable-item"
 import { toast } from "~/hooks/use-toast"
 import type { AdjRwResult } from "~/libs/adjrw-calculator"
 import { optimizeDiagnosis } from "~/libs/optimizer"
+import type { IcdCode } from "~/libs/types"
 
 export function RankingInterface() {
   const { selectedCodes, rankedCodes, setRankedCodes } = useDiagnosisStore()
@@ -93,14 +94,11 @@ export function RankingInterface() {
         return
       }
 
-      const order = [res.pdx, ...(res.sdx || [])].filter(Boolean) as string[]
-      const newRanked = order.map((code, idx) => {
-        const details = selectedCodes.find((c) => c.code === code)
-        return {
-          ...(details || { code, description: code, confidence: 1 }),
-          rank: idx + 1,
-        }
-      })
+      const order = [res.pdx, ...(res.sdx || [])].filter(Boolean) as IcdCode[]
+      const newRanked = order.map((code, idx) => ({
+        ...code,
+        rank: idx + 1,
+      }))
       setRankedCodes(newRanked)
 
       const score: AdjRwResult = {

--- a/apps/web/app/libs/optimizer.ts
+++ b/apps/web/app/libs/optimizer.ts
@@ -1,4 +1,5 @@
 import { apiPost } from './http'
+import type { IcdCode } from './types'
 
 export interface OptimizationRequest {
   availableCodes: string[]
@@ -7,8 +8,8 @@ export interface OptimizationRequest {
 
 export interface OptimizationResponse {
   success: boolean
-  pdx?: string
-  sdx?: string[]
+  pdx?: IcdCode
+  sdx?: IcdCode[]
   estimatedAdjRw?: number
   confidenceLevel?: string
   primaryWeight?: number


### PR DESCRIPTION
## Summary
- add IcdCode to API type definitions
- return pdx and sdx as IcdCode objects
- update validation schema for IcdCode
- adjust frontend optimizer types and ranking interface

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'hono', etc.)*
- `npx tsc --noEmit` in web *(fails: Cannot find type definition file for '@remix-run/node')*

------
https://chatgpt.com/codex/tasks/task_e_68563975de74832699ceb766705e83b7