### PR TITLE
Add ICD suggestion API integration

### DIFF
--- a/apps/web/app/components/diagnosis-input.tsx
+++ b/apps/web/app/components/diagnosis-input.tsx
@@ -27,12 +27,12 @@ export function DiagnosisInput() {
       await searchIcdCodes(diagnosisText)
       toast({
         title: "Search Complete",
-        description: "ICD-10 code suggestions have been generated.",
+        description: "ICD-10 and ICD-9 code suggestions have been generated.",
       })
     } catch (error) {
       toast({
         title: "Search Failed",
-        description: "Unable to generate ICD-10 suggestions. Please try again.",
+        description: "Unable to generate ICD code suggestions. Please try again.",
         variant: "destructive",
       })
     } finally {
@@ -65,12 +65,12 @@ export function DiagnosisInput() {
           {isSearching ? (
             <>
               <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-              Searching ICD-10 Codes...
+              Searching ICD Codes...
             </>
           ) : (
             <>
               <Search className="w-5 h-5 mr-2" />
-              Search ICD-10 Codes
+              Search ICD Codes
             </>
           )}
         </Button>

--- a/apps/web/app/components/icd-suggestions.tsx
+++ b/apps/web/app/components/icd-suggestions.tsx
@@ -8,7 +8,13 @@ import { useDiagnosisStore } from "~/libs/store"
 import type { IcdCode } from "~/libs/types"
 
 export function IcdSuggestions() {
-  const { suggestions, addSelectedCode, removeSelectedCode, selectedCodes } = useDiagnosisStore()
+  const {
+    icd10Suggestions,
+    icd9Suggestions,
+    addSelectedCode,
+    removeSelectedCode,
+    selectedCodes,
+  } = useDiagnosisStore()
 
   const isCodeSelected = (code: string) => {
     return selectedCodes.some((selected) => selected.code === code)
@@ -22,35 +28,21 @@ export function IcdSuggestions() {
     }
   }
 
-  if (suggestions.length === 0) {
-    return (
-      <div className="text-center py-8 text-gray-500">
-        <p>No ICD-10 suggestions found. Try refining your diagnosis description.</p>
-      </div>
-    )
-  }
-
-  return (
+  const renderGrid = (list: IcdCode[]) => (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {suggestions.map((suggestion) => (
+      {list.map((suggestion) => (
         <Card
           key={suggestion.code}
-          className={`transition-all hover:shadow-md ${isCodeSelected(suggestion.code) ? "ring-2 ring-green-500 bg-green-50" : "hover:border-blue-300"
-            }`}
+          className={`transition-all hover:shadow-md ${isCodeSelected(suggestion.code) ? "ring-2 ring-green-500 bg-green-50" : "hover:border-blue-300"}`}
         >
           <CardContent className="p-4">
             <div className="flex items-start justify-between mb-3">
               <Badge variant="outline" className="font-mono text-sm">
                 {suggestion.code}
               </Badge>
-              <Badge variant={suggestion.confidence > 0.8 ? "default" : "secondary"} className="text-xs">
-                {Math.round(suggestion.confidence * 100)}% match
-              </Badge>
             </div>
 
-            <h3 className="font-semibold text-gray-900 mb-2 line-clamp-2">{suggestion.description}</h3>
-
-            {suggestion.category && <p className="text-sm text-gray-600 mb-3">Category: {suggestion.category}</p>}
+            <h3 className="font-semibold text-gray-900 mb-4 line-clamp-2">{suggestion.description}</h3>
 
             <Button
               onClick={() => handleToggleCode(suggestion)}
@@ -72,6 +64,35 @@ export function IcdSuggestions() {
           </CardContent>
         </Card>
       ))}
+    </div>
+  )
+
+  if (icd10Suggestions.length === 0 && icd9Suggestions.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500">
+        <p>No ICD code suggestions found. Try refining your diagnosis description.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h3 className="text-xl font-semibold mb-4">ICD-10 Codes</h3>
+        {icd10Suggestions.length ? (
+          renderGrid(icd10Suggestions)
+        ) : (
+          <p className="text-gray-500">No ICD-10 suggestions found.</p>
+        )}
+      </div>
+      <div>
+        <h3 className="text-xl font-semibold mb-4">ICD-9 Codes</h3>
+        {icd9Suggestions.length ? (
+          renderGrid(icd9Suggestions)
+        ) : (
+          <p className="text-gray-500">No ICD-9 suggestions found.</p>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/app/libs/types.ts
+++ b/apps/web/app/libs/types.ts
@@ -5,6 +5,16 @@ export interface IcdCode {
   category?: string
 }
 
+export interface CodeDescription {
+  code: string
+  description: string
+}
+
+export interface IcdSuggestionResponse {
+  icd10: CodeDescription[]
+  icd9: CodeDescription[]
+}
+
 export interface PatientInfo {
   patientId: string
   firstName: string
@@ -18,7 +28,8 @@ export interface PatientInfo {
 
 export interface DiagnosisState {
   diagnosisText: string
-  suggestions: IcdCode[]
+  icd10Suggestions: IcdCode[]
+  icd9Suggestions: IcdCode[]
   selectedCodes: IcdCode[]
   rankedCodes: (IcdCode & { rank: number })[]
   patientInfo: PatientInfo


### PR DESCRIPTION
## Summary
- integrate `/suggest-icd` API in the front-end store
- display both ICD‑10 and ICD‑9 suggestions
- update diagnosis input messages
- define shared types for suggestions

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file)*
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_68564ff400c08326b25ecc8a06621974