### PR TITLE
Add dashboard page with mock statistics

### DIFF
--- a/apps/web/app/components/header.tsx
+++ b/apps/web/app/components/header.tsx
@@ -18,7 +18,7 @@ export function Header() {
           </div>
 
           <nav className="hidden md:flex items-center space-x-6">
-            <a href="#" className="text-gray-600 hover:text-[#115ad4] font-medium">
+            <a href="/dashboard" className="text-gray-600 hover:text-[#115ad4] font-medium">
               Dashboard
             </a>
             <a href="#" className="text-gray-600 hover:text-[#115ad4] font-medium">

--- a/apps/web/app/libs/dashboard-data.ts
+++ b/apps/web/app/libs/dashboard-data.ts
@@ -1,0 +1,21 @@
+export const dashboardStats = [
+  { label: "Cases Processed", value: 1248 },
+  { label: "Avg adj RW", value: 8.42 },
+  { label: "Codes per Case", value: 6 },
+  { label: "Success Rate", value: "93%" },
+]
+
+export const monthlyCases = [
+  { month: "Jan", cases: 102 },
+  { month: "Feb", cases: 98 },
+  { month: "Mar", cases: 110 },
+  { month: "Apr", cases: 105 },
+  { month: "May", cases: 120 },
+  { month: "Jun", cases: 115 },
+  { month: "Jul", cases: 130 },
+  { month: "Aug", cases: 125 },
+  { month: "Sep", cases: 128 },
+  { month: "Oct", cases: 135 },
+  { month: "Nov", cases: 140 },
+  { month: "Dec", cases: 150 },
+]

--- a/apps/web/app/routes/dashboard.tsx
+++ b/apps/web/app/routes/dashboard.tsx
@@ -1,0 +1,56 @@
+import { Header } from "~/components/header";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import {
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { dashboardStats, monthlyCases } from "~/libs/dashboard-data";
+
+export const meta = () => [{ title: "AudiMed | Dashboard" }];
+
+export default function Dashboard() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <main className="container mx-auto px-4 py-8 max-w-5xl space-y-8">
+        <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {dashboardStats.map((stat) => (
+            <Card key={stat.label}>
+              <CardHeader>
+                <CardTitle className="text-sm text-gray-500">
+                  {stat.label}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold text-gray-900">
+                  {stat.value}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+        <section className="bg-white rounded-lg shadow-sm border p-6">
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">
+            Cases Per Month
+          </h2>
+          <div className="w-full h-72">
+            <ResponsiveContainer>
+              <LineChart data={monthlyCases} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+                <XAxis dataKey="month" />
+                <YAxis />
+                <Tooltip />
+                <Line type="monotone" dataKey="cases" stroke="#115ad4" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add mock metrics in `dashboard-data.ts`
- create new dashboard page with stats and monthly cases chart
- link Dashboard in header navigation

## Testing
- `npm run lint` *(fails: Invalid option and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685664ed08108326a669cfba51a943b2