### PR TITLE
Add progress stepper to main interface

### DIFF
--- a/apps/web/app/components/progress-stepper.tsx
+++ b/apps/web/app/components/progress-stepper.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { Check } from "lucide-react"
+import { useDiagnosisStore } from "~/libs/store"
+import { cn } from "~/libs/utils"
+
+export function ProgressStepper() {
+  const {
+    isPatientInfoComplete,
+    icd10Suggestions,
+    icd9Suggestions,
+    selectedCodes,
+    rankedCodes,
+  } = useDiagnosisStore()
+
+  let currentStep = 1
+  if (isPatientInfoComplete()) currentStep = 2
+  if (icd10Suggestions.length > 0 || icd9Suggestions.length > 0) currentStep = 3
+  if (selectedCodes.length > 0) currentStep = 4
+  if (rankedCodes.length > 0) currentStep = 5
+
+  const steps = [
+    "Patient Info",
+    "Diagnosis Input",
+    "Code Suggestions",
+    "Diagnosis Ranking",
+    "Export",
+  ]
+
+  return (
+    <nav aria-label="Progress" className="mb-8">
+      <ol className="flex flex-wrap gap-4">
+        {steps.map((label, index) => {
+          const step = index + 1
+          const isCompleted = step < currentStep
+          const isActive = step === currentStep
+          return (
+            <li key={label} className="flex items-center">
+              <span
+                className={cn(
+                  "flex items-center justify-center w-8 h-8 rounded-full border text-sm font-medium mr-2",
+                  {
+                    "bg-[#115ad4] text-white border-[#115ad4]": isActive,
+                    "bg-green-500 text-white border-green-500": isCompleted,
+                    "bg-gray-200 text-gray-700 border-gray-300": !isActive && !isCompleted,
+                  },
+                )}
+              >
+                {isCompleted ? <Check className="w-4 h-4" /> : step}
+              </span>
+              <span
+                className={cn("text-sm font-medium", {
+                  "text-gray-900": isActive,
+                  "text-gray-500": !isActive,
+                })}
+              >
+                {label}
+              </span>
+              {step < steps.length && <span className="mx-2 text-gray-400">/</span>}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import { RankingInterface } from "~/components/ranking-interface"
 import { ExportOptions } from "~/components/export-options"
 import { Header } from "~/components/header"
 import { PatientInformation } from "~/components/patient-information"
+import { ProgressStepper } from "~/components/progress-stepper"
 import { useDiagnosisStore } from "~/libs/store"
 
 export const meta: MetaFunction = () => {
@@ -23,6 +24,7 @@ export default function Index() {
       <Header />
 
       <main className="container mx-auto px-4 py-8 max-w-6xl">
+        <ProgressStepper />
         <div className="space-y-8">
           {/* Patient Information Section - Always First */}
           <section>


### PR DESCRIPTION
## Summary
- show current workflow progress with new `ProgressStepper` component
- include stepper at the top of the main index page

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@remix-run/node')*

------
https://chatgpt.com/codex/tasks/task_e_685a74beb4348326b5e8cd49282a412a