### PR TITLE
Implement interactive loading UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# audimed-api
+
+This repository contains the Audimed API and web applications.
+
+Last updated: 2025-06-24 10:27:19 UTC

--- a/apps/web/app/components/diagnosis-input.tsx
+++ b/apps/web/app/components/diagnosis-input.tsx
@@ -6,11 +6,13 @@ import { Button } from "~/components/ui/button"
 import { Search, Loader2 } from "lucide-react"
 import { useDiagnosisStore } from "~/libs/store"
 import { toast } from "~/hooks/use-toast"
+import { useInteractiveLoading } from "~/hooks/use-interactive-loading"
 
 export function DiagnosisInput() {
   const { diagnosisText, setDiagnosisText, searchIcdCodes } = useDiagnosisStore()
   const [isSearching, setIsSearching] = useState(false)
   const maxLength = 2000
+  const { start, finish, setLoading } = useInteractiveLoading()
 
   const handleSearch = async () => {
     if (!diagnosisText.trim()) {
@@ -23,6 +25,8 @@ export function DiagnosisInput() {
     }
 
     setIsSearching(true)
+    start()
+    setLoading({ stage: 'processing' })
     try {
       await searchIcdCodes(diagnosisText)
       toast({
@@ -36,6 +40,7 @@ export function DiagnosisInput() {
         variant: "destructive",
       })
     } finally {
+      finish()
       setIsSearching(false)
     }
   }

--- a/apps/web/app/components/interactive-loading/custom-spinner.tsx
+++ b/apps/web/app/components/interactive-loading/custom-spinner.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react"
+
+export function CustomSpinner({
+  onComplete,
+}: {
+  onComplete?: (color: string) => void
+}) {
+  const [color, setColor] = useState("#3b82f6")
+
+  const change = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setColor(value)
+    onComplete?.(value)
+  }
+
+  return (
+    <div className="space-y-2 text-center">
+      <div
+        className="w-8 h-8 mx-auto rounded-full border-4 border-t-transparent animate-spin"
+        style={{ borderColor: `${color}` }}
+      />
+      <input type="color" value={color} onChange={change} />
+    </div>
+  )
+}

--- a/apps/web/app/components/interactive-loading/facts-carousel.tsx
+++ b/apps/web/app/components/interactive-loading/facts-carousel.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react"
+
+const FACTS = [
+  "Did you know? Short prompts often yield clearer results.",
+  "Tip: Specify desired format to improve responses.",
+  "You can ask for multiple suggestions in one query.",
+]
+
+export function AiFactsCarousel({
+  onComplete,
+}: {
+  onComplete?: (factIndex: number) => void
+}) {
+  const [index, setIndex] = useState(0)
+
+  const next = () => {
+    const newIndex = (index + 1) % FACTS.length
+    setIndex(newIndex)
+    onComplete?.(newIndex)
+  }
+
+  return (
+    <div className="space-y-2 text-center">
+      <p>{FACTS[index]}</p>
+      <button
+        className="px-2 py-1 bg-blue-500 text-white rounded"
+        onClick={next}
+      >
+        Next
+      </button>
+    </div>
+  )
+}

--- a/apps/web/app/components/interactive-loading/index.ts
+++ b/apps/web/app/components/interactive-loading/index.ts
@@ -1,0 +1,4 @@
+export { LoadingManager } from './loading-manager'
+export { MiniWordGame } from './word-game'
+export { AiFactsCarousel } from './facts-carousel'
+export { CustomSpinner } from './custom-spinner'

--- a/apps/web/app/components/interactive-loading/loading-manager.tsx
+++ b/apps/web/app/components/interactive-loading/loading-manager.tsx
@@ -1,0 +1,42 @@
+import { InteractiveElement, useInteractiveLoading } from "~/hooks/use-interactive-loading"
+
+export function LoadingManager({
+  interactiveElements,
+}: {
+  interactiveElements: InteractiveElement[]
+}) {
+  const { loading, cancel, registerResult } = useInteractiveLoading()
+
+  if (!loading.isLoading) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded shadow-lg space-y-4 w-80">
+        <div className="flex justify-between items-center">
+          <p className="font-semibold">Loading... {loading.stage}</p>
+          <button className="text-sm text-red-500" onClick={cancel}>
+            Cancel
+          </button>
+        </div>
+        <div className="h-2 bg-gray-200 rounded">
+          <div
+            className="bg-blue-500 h-full rounded transition-all"
+            style={{ width: `${loading.progress ?? 0}%` }}
+          />
+        </div>
+        {interactiveElements.map((el, i) => {
+          const Component = el.component
+          return (
+            <Component
+              key={i}
+              onComplete={(r) => {
+                el.onComplete?.(r)
+                registerResult(el.type + i, r)
+              }}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/components/interactive-loading/word-game.tsx
+++ b/apps/web/app/components/interactive-loading/word-game.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react"
+
+const WORDS = ["react", "next", "state", "hook", "async"]
+
+export function MiniWordGame({
+  onComplete,
+}: {
+  onComplete?: (score: number) => void
+}) {
+  const [current, setCurrent] = useState(WORDS[0])
+  const [input, setInput] = useState("")
+  const [start, setStart] = useState<number | null>(null)
+  const [typed, setTyped] = useState(0)
+
+  const reset = () => {
+    setCurrent(WORDS[Math.floor(Math.random() * WORDS.length)])
+    setInput("")
+    setStart(Date.now())
+  }
+
+  useEffect(() => {
+    reset()
+  }, [])
+
+  useEffect(() => {
+    if (input === current && start) {
+      const wpm = 1 / ((Date.now() - start) / 60000)
+      setTyped((t) => t + 1)
+      onComplete?.(wpm)
+      reset()
+    }
+  }, [input, current, start, onComplete])
+
+  return (
+    <div className="space-y-2">
+      <p>
+        Type the word: <strong>{current}</strong>
+      </p>
+      <input
+        className="border p-2 rounded w-full"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <p className="text-sm text-gray-500">Words typed: {typed}</p>
+    </div>
+  )
+}

--- a/apps/web/app/components/ranking-interface.tsx
+++ b/apps/web/app/components/ranking-interface.tsx
@@ -16,6 +16,7 @@ import { toast } from "~/hooks/use-toast"
 import type { AdjRwResult } from "~/libs/adjrw-calculator"
 import { optimizeDiagnosis } from "~/libs/optimizer"
 import type { IcdCode } from "~/libs/types"
+import { useInteractiveLoading } from "~/hooks/use-interactive-loading"
 
 export function RankingInterface() {
   const { selectedCodes, rankedCodes, setRankedCodes } = useDiagnosisStore()
@@ -23,6 +24,7 @@ export function RankingInterface() {
   const [adjRwScore, setAdjRwScore] = useState<AdjRwResult | null>(null)
   const [hasManuallyReordered, setHasManuallyReordered] = useState(false)
   const [isCalculating, setIsCalculating] = useState(false)
+  const { start, finish, setLoading } = useInteractiveLoading()
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -82,6 +84,8 @@ export function RankingInterface() {
     if (selectedCodes.length === 0) return
 
     setIsCalculating(true)
+    start()
+    setLoading({ stage: 'processing' })
 
     console.log(selectedCodes);
 
@@ -143,6 +147,7 @@ export function RankingInterface() {
         variant: "destructive",
       })
     } finally {
+      finish()
       setIsCalculating(false)
     }
   }

--- a/apps/web/app/hooks/use-interactive-loading.ts
+++ b/apps/web/app/hooks/use-interactive-loading.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand"
+import { useEffect } from "react"
+import { useLocalStorage } from "~/hooks/use-local-storage"
+
+export interface LoadingState {
+  isLoading: boolean
+  progress?: number
+  estimatedTime?: number
+  stage?: 'connecting' | 'processing' | 'finalizing'
+}
+
+export interface InteractiveElement {
+  type: 'game' | 'info' | 'customization' | 'chat'
+  component: React.ComponentType<{ onComplete?: (result: any) => void }>
+  onComplete?: (result: any) => void
+}
+
+type Store = {
+  loading: LoadingState
+  interactions: Record<string, any>
+  setLoading: (s: Partial<LoadingState>) => void
+  start: () => void
+  finish: () => void
+  cancel: () => void
+  registerResult: (key: string, value: any) => void
+}
+
+const useInteractiveLoadingStore = create<Store>((set) => ({
+  loading: { isLoading: false },
+  interactions: {},
+  setLoading: (s) => set((state) => ({ loading: { ...state.loading, ...s } })),
+  start: () =>
+    set({
+      loading: { isLoading: true, progress: 0, stage: 'connecting' },
+    }),
+  finish: () =>
+    set({
+      loading: { isLoading: false, progress: 100, stage: 'finalizing' },
+    }),
+  cancel: () => set({ loading: { isLoading: false } }),
+  registerResult: (key, value) =>
+    set((state) => ({ interactions: { ...state.interactions, [key]: value } })),
+}))
+
+export function useInteractiveLoading() {
+  const [stored, setStored] = useLocalStorage<Record<string, any>>(
+    'loadingInteractions',
+    {}
+  )
+  const store = useInteractiveLoadingStore()
+
+  useEffect(() => {
+    setStored(store.interactions)
+  }, [store.interactions, setStored])
+
+  return { ...store, interactions: stored }
+}

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -8,6 +8,12 @@ import { Header } from "~/components/header"
 import { PatientInformation } from "~/components/patient-information"
 import { ProgressStepper } from "~/components/progress-stepper"
 import { useDiagnosisStore } from "~/libs/store"
+import {
+  LoadingManager,
+  MiniWordGame,
+  AiFactsCarousel,
+  CustomSpinner,
+} from "~/components/interactive-loading"
 
 export const meta: MetaFunction = () => {
   return [
@@ -22,6 +28,14 @@ export default function Index() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
+
+      <LoadingManager
+        interactiveElements={[
+          { type: 'game', component: MiniWordGame },
+          { type: 'info', component: AiFactsCarousel },
+          { type: 'customization', component: CustomSpinner },
+        ]}
+      />
 
       <main className="container mx-auto px-4 py-8 max-w-6xl">
         <ProgressStepper />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "dev": "remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "remix-serve ./build/server/index.js",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test": "vitest --config vitest.config.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -85,7 +86,9 @@
     "tailwindcss": "^3.4.4",
     "typescript": "^5.1.6",
     "vite": "^6.0.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/apps/web/tests/useInteractiveLoading.test.ts
+++ b/apps/web/tests/useInteractiveLoading.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useInteractiveLoading } from '../app/hooks/use-interactive-loading'
+
+describe('useInteractiveLoading', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('manages loading lifecycle', () => {
+    const { result } = renderHook(() => useInteractiveLoading())
+
+    act(() => {
+      result.current.start()
+    })
+
+    expect(result.current.loading.isLoading).toBe(true)
+
+    act(() => {
+      result.current.finish()
+    })
+
+    expect(result.current.loading.isLoading).toBe(false)
+    expect(result.current.loading.progress).toBe(100)
+  })
+})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add Zustand hook `useInteractiveLoading`
- implement interactive loading components (word game, facts carousel, custom spinner)
- add `LoadingManager` container to display elements during API calls
- configure `vitest` and write basic unit test
- hook loading overlay into ICD search and ranking operations

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7d4637748326a664f354136e9648