### PR TITLE
Fix ICD suggestion fetch errors

### DIFF
--- a/apps/web/app/libs/store.ts
+++ b/apps/web/app/libs/store.ts
@@ -22,25 +22,31 @@ export const useDiagnosisStore = create<DiagnosisState>((set, get) => ({
   setDiagnosisText: (text: string) => set({ diagnosisText: text }),
 
   searchIcdCodes: async (text: string) => {
-    const data = await apiGet<IcdSuggestionResponse>('/suggest-icd', {
-      params: { diagnosis: text },
-    })
+    try {
+      const data = await apiGet<IcdSuggestionResponse>("/suggest-icd", {
+        params: { diagnosis: text },
+      })
 
-    const icd10Suggestions: IcdCode[] = data.icd10.map((c) => ({
-      code: c.code,
-      description: c.description,
-      confidence: 1.0,
-      category: "icd10",
-    }))
+      const icd10Suggestions: IcdCode[] = (data.icd10 ?? []).map((c) => ({
+        code: c.code,
+        description: c.description,
+        confidence: 1.0,
+        category: "icd10",
+      }))
 
-    const icd9Suggestions: IcdCode[] = data.icd9.map((c) => ({
-      code: c.code,
-      description: c.description,
-      confidence: 1.0,
-      category: "icd9",
-    }))
+      const icd9Suggestions: IcdCode[] = (data.icd9 ?? []).map((c) => ({
+        code: c.code,
+        description: c.description,
+        confidence: 1.0,
+        category: "icd9",
+      }))
 
-    set({ icd10Suggestions, icd9Suggestions })
+      set({ icd10Suggestions, icd9Suggestions })
+    } catch (error) {
+      console.error("Failed to fetch ICD suggestions", error)
+      set({ icd10Suggestions: [], icd9Suggestions: [] })
+      throw error
+    }
   },
 
   addSelectedCode: (code: IcdCode) => {


### PR DESCRIPTION
## Summary
- prevent stale suggestions when requesting ICD codes
- show console error when ICD suggestion fetch fails

## Testing
- `npm run lint` *(fails: Invalid option and missing dependencies)*
- `npm run typecheck` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_685d0272d2c08326b45a9154d2f5a5cf